### PR TITLE
Pass client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,10 @@
-🚧 **work in progress** 🚧 
-#### This project is in active development and not stable
-#### Things might change at any time
- 
  # Drop In Tileservice
 
 A drop in vector tile service using pg for turning any postres backend into a tileserver.
 
 ### Pre Requisites:
 
-- [PostgreSQL](https://www.postgresql.org/) with [PostGIS](http://postgis.net/) installed.
+- [PostgreSQL](https://www.postgresql.org/) with the [PostGIS](http://postgis.net/) extension added.
 - This Package requires the [node-postgres](https://node-postgres.com/) package
 
 ### Installation 
@@ -39,19 +35,22 @@ const connection_params = {
 
 const pool = new Pool(connection_params)
 
-const tileService = new Tileserver(pool)
+const tileService = new Tileserver()
 //SQL to be run against the pool db
 tileservice.setQuery("SELECT id, geom FROM schema.table WHERE prop = 44") 
 tileservice.setSrid(2252) //Michigan Central
 
 app.get("/tiles/:z/:x/:y", async (req, res) => {
     try {
-        const tiles = await ts.query(req.params.z, req.params.x, req.params.y, {
+        const conn = await pool.connect()
+        const tiles = await ts.query(req.params.z, req.params.x, req.params.y, conn {
             layername: "default"
         })
         res.status(200).send(tiles) //protobuf sent as result 
     } catch (e) {
         console.log(e)
+    } finally {
+        await conn.release()
     }
 
 })
@@ -65,13 +64,16 @@ tileservice.setSrid(2252) //Michigan Central
 
 app.get("/tiles/:z/:x/:y", async (req, res) => {
     try {
-        const tiles = await ts.query(req.params.z, req.params.x, req.params.y, {
+        const conn = await pool.connect()
+        const tiles = await ts.query(req.params.z, req.params.x, req.params.y, conn, {
             params: [44],
             layername: "default"
         })
         res.status(200).send(tiles) //protobuf sent as result 
     } catch (e) {
         console.log(e)
+    } finally {
+        await conn.release()
     }
 })
 ```
@@ -81,7 +83,8 @@ app.get("/tiles/:z/:x/:y", async (req, res) => {
 ```javascript
 app.get("/tiles/:z/:x/:y", async (req, res) => {
     try {
-        const tiles = await ts.query(req.params.z, req.params.x, req.params.y, {
+        const conn = await pool.connect()
+        const tiles = await ts.query(req.params.z, req.params.x, req.params.y, conn, {
             queryString: "SELECT id, geom FROM schema.table WHERE prop = $1",
             srid: 2252,
             params: [44],
@@ -90,6 +93,8 @@ app.get("/tiles/:z/:x/:y", async (req, res) => {
         res.status(200).send(tiles) //protobuf sent as result 
     } catch (e) {
         console.log(e)
+    } finally {
+        await conn.release()
     }
 })
 ```

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ tileservice.setSrid(2252) //Michigan Central
 app.get("/tiles/:z/:x/:y", async (req, res) => {
     try {
         const conn = await pool.connect()
-        const tiles = await ts.query(req.params.z, req.params.x, req.params.y, conn {
+        const tiles = await ts.query(req.params.z, req.params.x, req.params.y, conn, {
             layername: "default"
         })
         res.status(200).send(tiles) //protobuf sent as result 

--- a/src/__tests__/tile.ts
+++ b/src/__tests__/tile.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from '@jest/globals';
-import { tileExt, nTiles, makeEnvelopeFromTileCoord, validateTileCoords } from '../util/tile';
+import { tileExt, nTiles, makeBboxFromTileCoord, validateTileCoords } from '../util/tile';
 
 describe('tile utilities', () => {
   test('find tile extent at given zoom', () => {
@@ -13,7 +13,7 @@ describe('tile utilities', () => {
   });
 
   test('find the envelope for and zxy set', () => {
-    const res = makeEnvelopeFromTileCoord(3, 3, 4);
+    const res = makeBboxFromTileCoord(3, 3, 4);
     expect(res).toStrictEqual({
       xMin: -5009377.085697301,
       xMax: 0.0,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { Client, Pool, QueryResult } from 'pg';
+import { Client, QueryResult } from 'pg';
 import { IQueryOptions } from './types';
 import { makeBboxFromTileCoord } from './util/tile';
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-export interface ITileEnvelope {
+export interface ITileBbox {
   xMin: number;
   xMax: number;
   yMin: number;

--- a/src/util/tile.ts
+++ b/src/util/tile.ts
@@ -1,4 +1,4 @@
-import { ITileEnvelope } from '../types';
+import { ITileBbox } from '../types';
 
 export function tileExt(zoom: number): number {
   //tile width at zoom level `zoom`
@@ -10,7 +10,7 @@ export function nTiles(zoom: number): number {
   return 2 ** (2 * zoom);
 }
 
-export function makeEnvelopeFromTileCoord(z: number, x: number, y: number): ITileEnvelope {
+export function makeBboxFromTileCoord(z: number, x: number, y: number): ITileBbox {
   const webMercMax = 20037508.3427892;
   const webMercMin = -1 * webMercMax;
   const worldSize = webMercMax - webMercMin;


### PR DESCRIPTION
- Remove the requirement to pass a pool to the `Tileserver` constructor. Pass a connection instead and do connection management outside of the `Tileserver` instance.